### PR TITLE
Feat/add new streams with pagination

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What type of PR is this? (check all applicable)
+
+- [ ] Refactor
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Optimization
+- [ ] Documentation Update
+
+## Description

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,11 @@
 
 name: Test tap-getresponse
 
-on: [push]
+on:
+  push:
+    paths:
+      - tap_getresponse/**
+      - tests/
 
 jobs:
   pytest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,7 @@ jobs:
       run: |
         poetry install
     - name: Test with pytest
+      env:
+        TAP_GETRESPONSE_AUTH_TOKEN: ${{ secrets.TAP_GETRESPONSE_AUTH_TOKEN }}
       run: |
         poetry run pytest

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# tap-getresponse
+# <h1 align="center">Tap-GetResponse</h1>
+
 
 `tap-getresponse` is a Singer tap for GetResponse.
 
+![logo](https://www.ekito.fr/wp-content/uploads/2021/07/getresponse_logo.png)
+
 Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
+
 
 <!--
 
@@ -24,26 +28,14 @@ pipx install git+https://github.com/ORG_NAME/tap-getresponse.git@main
 
 -->
 
-## Configuration
+## Configuration 📝
 
 ### Accepted Config Options
 
-<!--
-Developer TODO: Provide a list of config options accepted by the tap.
 
-This section can be created by copy-pasting the CLI output from:
-
-```
-tap-getresponse --about --format=markdown
-```
--->
-
-A full list of supported settings and capabilities for this
-tap is available by running:
-
-```bash
-tap-getresponse --about
-```
+| Setting    | Required | Default | Description            |
+| :--------- | :------: | :-----: | :--------------------- |
+| auth_token |   True   |  None   | GetResponse token API. |
 
 ### Configure using environment variables
 
@@ -51,11 +43,15 @@ This Singer tap will automatically import any environment variables within the w
 `.env` if the `--config=ENV` is provided, such that config values will be considered if a matching
 environment variable is set either in the terminal context or in the `.env` file.
 
+
+```
+# .env
+TAP_GETRESPONSE_AUTH_TOKEN=... # your token!
+```
+
 ### Source Authentication and Authorization
 
-<!--
-Developer TODO: If your tap requires special access on the source system, or any special authentication requirements, provide those here.
--->
+To get your API Token, follow the [official documentation](https://apidocs.getresponse.com/v3/authentication).
 
 ## Usage
 

--- a/tap_getresponse/schemas/newsletter_activities.json
+++ b/tap_getresponse/schemas/newsletter_activities.json
@@ -1,0 +1,58 @@
+{
+    "type": "object",
+    "properties": {
+        "newsletterId": {
+            "type": [
+                "string"
+            ]
+        },
+        "activities": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "activity": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "createdOn": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "contact": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "contactId": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "href": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uri"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "newsletterId"
+    ]
+}

--- a/tap_getresponse/schemas/newsletter_details.json
+++ b/tap_getresponse/schemas/newsletter_details.json
@@ -1,0 +1,89 @@
+{
+    "type": "object",
+    "properties": {
+        "newsletterId": {
+            "type": [
+                "string"
+            ],
+            "description": "The newsletter ID"
+        },
+        "name": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The newsletter name"
+        },
+        "href": {
+            "type": [
+                "string"
+            ],
+            "format": "uri",
+            "description": "Direct hyperlink to a resource"
+        },
+        "type": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The newsletter type"
+        },
+        "status": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The newsletter status"
+        },
+        "subject": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The message subject"
+        },
+        "createdOn": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "format": "date-time",
+            "description": "The creation date"
+        },
+        "sendOn": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "format": "date-time",
+            "description": "The scheduled send date and time for the newsletter in the ISO 8601 format."
+        },
+        "content": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "html": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The message content in HTML"
+                },
+                "plain": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The plain text equivalent of the message content"
+                }
+            },
+            "description": "The message content."
+        }
+    },
+    "required": [
+        "newsletterId",
+        "href"
+    ]
+}

--- a/tap_getresponse/streams.py
+++ b/tap_getresponse/streams.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import typing as t
+from pathlib import Path
 
+import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
-from tap_getresponse.client import GetResponseStream
+from tap_getresponse.client import GetResponseStream, extract_jsonpath
+
+SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 
 class CampaignsStream(GetResponseStream):
@@ -55,6 +59,70 @@ class CampaignsStream(GetResponseStream):
             "href",
             th.URIType,
             description="Direct hyperlink to a resource",
+        ),
+    ).to_dict()  # type: ignore
+
+    # Source: https://sdk.meltano.com/en/v0.25.0/parent_streams.html
+    def get_child_context(self, record: dict, context: t.Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "campaignId": record["campaignId"],
+        }
+
+
+# Source: https://sdk.meltano.com/en/v0.25.0/parent_streams.html
+class CampaignDetailsStream(GetResponseStream):
+    """Get a single campaign by the campaign ID"""
+
+    name = "campaign_details"
+    path = "/campaigns/{campaignId}"
+
+    parent_stream_type = CampaignsStream
+
+    primary_keys: t.ClassVar[list[str]] = ["campaignId"]
+
+    schema = th.PropertiesList(
+        th.Property(
+            "campaignId",
+            th.StringType,
+            description="Campaign ID",
+        ),
+        th.Property(
+            "name",
+            th.StringType,
+            required=True,
+            description="The campaign (list) name.",
+        ),
+        th.Property(
+            "confirmation",
+            th.ObjectType(
+                th.Property(
+                    "fromField",
+                    th.ObjectType(
+                        th.Property(
+                            "fromFieldId",
+                            th.StringType,
+                            required=True,
+                            description="The 'From' address ID",
+                        ),
+                        th.Property(
+                            "href",
+                            th.URIType,
+                            description="Direct hyperlink to a resource",
+                        ),
+                    ),
+                ),
+                th.Property(
+                    "mimeType",
+                    th.StringType,
+                    description="The MIME type for the confirmation message",
+                ),
+                th.Property(
+                    "redirectUrl",
+                    th.URIType,
+                    description="The URL a subscriber will be redirected to if the redirectType is set to customUrl",
+                ),
+            ),
         ),
     ).to_dict()  # type: ignore
 
@@ -134,3 +202,155 @@ class ContactsStream(GetResponseStream):
         #     description="The contact's IP address. IPv4 and IPv6 formats are accepted.",
         # ),
     ).to_dict()  # type: ignore
+
+
+class NewslettersStream(GetResponseStream):
+    """Get the list of newsletters"""
+
+    name = "newsletters"
+    path = "/newsletters"
+    primary_keys: t.ClassVar[list[str]] = ["newsletterId"]
+
+    schema = th.PropertiesList(
+        th.Property(
+            "newsletterId",
+            th.StringType,
+            required=True,
+            description="The newsletter ID",
+        ),
+        th.Property(
+            "href",
+            th.URIType,
+            required=True,
+            description="Direct hyperlink to a resource",
+        ),
+        th.Property(
+            "name",
+            th.StringType,
+            description="The newsletter name",
+        ),
+        th.Property(
+            "type",
+            th.StringType,
+            # TODO: add  Enum:"broadcast" "draft"
+            description="The newsletter type",
+        ),
+        th.Property(
+            "status",
+            th.StringType,
+            # TODO: add  Enum:"enabled" "disabled"
+            description="The newsletter status",
+        ),
+        th.Property(
+            "editor",
+            th.StringType,
+            # TODO: Enum:"custom" "text" "getresponse" "legacy" "html2"
+            description="This describes how the content of the message was created",
+        ),
+        th.Property(
+            "subject",
+            th.StringType,
+            description="The message subject",
+        ),
+        th.Property(
+            "campaign",
+            th.ObjectType(
+                th.Property(
+                    "campaignId",
+                    th.StringType,
+                    required=True,
+                    description="Campaign ID",
+                ),
+                th.Property(
+                    "href",
+                    th.URIType,
+                    description="Direct hyperlink to a resource",
+                ),
+                th.Property(
+                    "name",
+                    th.StringType,
+                    description="The campaign name",
+                ),
+            ),
+            description="The newsletter must be assigned to a campaign",
+        ),
+        th.Property(
+            "sendOn",
+            th.DateTimeType,
+            description="The scheduled send date and time for the newsletter in the ISO 8601 format",
+        ),
+        th.Property(
+            "createdOn",
+            th.DateTimeType,
+            description="The creation date",
+        ),
+        th.Property(
+            "sendMetrics",
+            th.ObjectType(
+                # TODO: Enum:"scheduled" "in_progress" "finished"
+                th.Property(
+                    "status",
+                    th.StringType,
+                ),
+                th.Property(
+                    "sent",
+                    th.StringType,
+                    description="Messages already sent",
+                ),
+                th.Property(
+                    "total",
+                    th.StringType,
+                    description="The total amount of messages to send",
+                ),
+            ),
+            description="The sending metrics",
+        ),
+        th.Property(
+            "flags",
+            th.StringType,
+            description="Comma-separated list of message flags. The possible values are: openrate, clicktrack, and google_analytics.",
+        ),
+    ).to_dict()  # type: ignore
+
+    # Source: https://sdk.meltano.com/en/v0.25.0/parent_streams.html
+    def get_child_context(self, record: dict, context: t.Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "newsletterId": record["newsletterId"],
+        }
+
+
+class NewsletterDetailsStream(GetResponseStream):
+    """Get a single newsletter by its ID"""
+
+    name = "newsletter_details"
+    path = "/newsletters/{newsletterId}"
+
+    parent_stream_type = NewslettersStream
+
+    primary_keys: t.ClassVar[list[str]] = ["newsletterId"]
+
+    schema_filepath = SCHEMAS_DIR / "newsletter_details.json"  # type: ignore
+
+
+class NewsletterActivitiesStream(GetResponseStream):
+    """
+    Get newsletter activities.
+
+    By default, activities from the last 14 days are listed only.
+    """
+
+    name = "newsletter_activities"
+    path = "/newsletters/{newsletterId}/activities"
+
+    parent_stream_type = NewslettersStream
+
+    schema_filepath = SCHEMAS_DIR / "newsletter_activities.json"  # type: ignore
+
+    def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
+        """The response must be parsed to convert to raw result which is a list to a dict"""
+
+        data = response.json()
+        input_ = {"activities": data}
+
+        yield from extract_jsonpath(self.records_jsonpath, input=input_)

--- a/tap_getresponse/tap.py
+++ b/tap_getresponse/tap.py
@@ -31,7 +31,11 @@ class TapGetResponse(Tap):
         """
         return [
             streams.CampaignsStream(self),
+            streams.CampaignDetailsStream(self),
             streams.ContactsStream(self),
+            streams.NewslettersStream(self),
+            streams.NewsletterDetailsStream(self),
+            streams.NewsletterActivitiesStream(self),
         ]
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,13 +1,14 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
 import datetime
+import os
 
 from singer_sdk.testing import get_tap_test_class
 
 from tap_getresponse.tap import TapGetResponse
 
 SAMPLE_CONFIG = {
-    "auth_token": "auth_token",
+    "auth_token": os.getenv("GETRESPONSE_AUTH_TOKEN"),
 }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
-import datetime
 import os
 
 from singer_sdk.testing import get_tap_test_class


### PR DESCRIPTION
# New

- Add new streams:
  - `CampaignDetailsStream`
  - `NewslettersStream`
  - `NewsletterDetailsStream`
  - `NewsletterActivitiesStream`

# Fix

- Run `test.yml` workflow on changes in `tap_getresponse` or `tests` changes 